### PR TITLE
SDK-398: Update Maven Parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,26 +4,26 @@
 
 	<groupId>org.openmrs.maven.parents</groupId>
 	<artifactId>maven-parent-openmrs-module</artifactId>
-	<version>1.1.2-SNAPSHOT</version>
+	<version>2.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>OpenMRS Module Parent POM</name>
 	<description>Declares parent POM for any OpenMRS module</description>
-	
+
 	<issueManagement>
 		<system>JIRA</system>
-		<url>http://issues.openmrs.org/</url>
+		<url>https://issues.openmrs.org/</url>
 	</issueManagement>
-	
+
 	<licenses>
 		<license>
-			<name>OpenMRS Public License</name>
-			<url>http://openmrs.org/wiki/License</url>
+			<name>Mozilla Public License, Version 2.0 with Healthcare Disclaimer</name>
+			<url>https://openmrs.org/license</url>
 		</license>
 	</licenses>
-	
+
 	<organization>
 		<name>OpenMRS LLC.</name>
-		<url>http://openmrs.org</url>
+		<url>https://openmrs.org</url>
 	</organization>
 
 	<scm>
@@ -39,21 +39,21 @@
 			<name>OpenMRS Releases</name>
 			<url>https://mavenrepo.openmrs.org/releases</url>
 		</repository>
-        <snapshotRepository>
-            <id>openmrs-repo-snapshots</id>
-            <name>OpenMRS Snapshots</name>
-            <url>https://mavenrepo.openmrs.org/snapshots</url>
-        </snapshotRepository>
+		<snapshotRepository>
+			<id>openmrs-repo-snapshots</id>
+			<name>OpenMRS Snapshots</name>
+			<url>https://mavenrepo.openmrs.org/snapshots</url>
+		</snapshotRepository>
 	</distributionManagement>
-	
+
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		
-		<javaCompilerSource>1.8</javaCompilerSource>
-		<javaCompilerTarget>1.8</javaCompilerTarget>
-		
+
+		<maven.compiler.source>8</maven.compiler.source>
+		<maven.compiler.target>8</maven.compiler.target>
+
 		<openmrsPlatformVersion>2.0.0</openmrsPlatformVersion>
-		<openmrsPlatformToolsVersion>2.0.0</openmrsPlatformToolsVersion>
+		<openmrsPlatformToolsVersion>${openmrsPlatformVersion}</openmrsPlatformToolsVersion>
 
 		<MODULE_ID>${project.parent.artifactId}</MODULE_ID>
 		<MODULE_NAME>${project.parent.name}</MODULE_NAME>
@@ -120,7 +120,7 @@
 		</dependency>
 	</dependencies>
 
-	<build>		
+	<build>
 		<resources>
 			<resource>
 				<directory>src/main/resources</directory>
@@ -140,7 +140,7 @@
 					<exclude>**/*.properties</exclude>
 				</excludes>
 			</resource>
-			
+
 			<resource>
 				<directory>src/main/webapp</directory>
 				<filtering>true</filtering>
@@ -162,7 +162,7 @@
 				<targetPath>web/module</targetPath>
 			</resource>
 		</resources>
-		
+
 		<testResources>
 			<testResource>
 				<directory>src/test/resources</directory>
@@ -183,16 +183,13 @@
 				</excludes>
 			</testResource>
 		</testResources>
-		
+
 		<pluginManagement>
 			<plugins>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<configuration>
-						<target>${javaCompilerTarget}</target>
-						<source>${javaCompilerSource}</source>
-					</configuration>
+					<version>3.15.0</version>
 				</plugin>
 
 				<plugin>
@@ -214,7 +211,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jar-plugin</artifactId>
-					<version>2.5</version>
+					<version>3.5.0</version>
 					<executions>
 						<execution>
 							<goals>
@@ -227,31 +224,19 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-release-plugin</artifactId>
-					<version>2.5.3</version>
+					<version>3.3.1</version>
 					<configuration>
 						<useReleaseProfile>false</useReleaseProfile>
 						<autoVersionSubmodules>true</autoVersionSubmodules>
 						<arguments>-Prelease</arguments>
-                        <tagNameFormat>@{project.version}</tagNameFormat>
+						<tagNameFormat>@{project.version}</tagNameFormat>
 					</configuration>
 				</plugin>
 
 				<plugin>
-					<groupId>com.googlecode.maven-java-formatter-plugin</groupId>
-					<artifactId>maven-java-formatter-plugin</artifactId>
-					<version>0.4</version>
-					<configuration>
-						<configFile>eclipse/OpenMRSFormatter.xml</configFile>
-						<overrideConfigCompilerVersion>true</overrideConfigCompilerVersion>
-						<lineEnding>LF</lineEnding>
-					</configuration>
-					<executions>
-						<execution>
-							<goals>
-								<goal>format</goal>
-							</goals>
-						</execution>
-					</executions>
+					<groupId>com.diffplug.spotless</groupId>
+					<artifactId>spotless-maven-plugin</artifactId>
+					<version>2.30.0</version>
 					<dependencies>
 						<dependency>
 							<groupId>org.openmrs.tools</groupId>
@@ -259,12 +244,28 @@
 							<version>${openmrsPlatformToolsVersion}</version>
 						</dependency>
 					</dependencies>
+					<configuration>
+						<java>
+							<eclipse>
+								<file>eclipse/OpenMRSFormatter.xml</file>
+							</eclipse>
+							<lineEndings>UNIX</lineEndings>
+						</java>
+					</configuration>
+					<executions>
+						<execution>
+							<id>spotless-format</id>
+							<goals>
+								<goal>apply</goal>
+							</goals>
+						</execution>
+					</executions>
 				</plugin>
 
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>buildnumber-maven-plugin</artifactId>
-					<version>1.1</version>
+					<version>3.2.1</version>
 					<configuration>
 						<buildNumberPropertyName>revisionNumber</buildNumberPropertyName>
 						<getRevisionOnlyOnce>true</getRevisionOnlyOnce>
@@ -280,13 +281,14 @@
 						</execution>
 					</executions>
 				</plugin>
-				
-				<!-- Extracting messages and Spring configuration out of the API jar. 
-					 It is needed due to a bug in OpenMRS, which prevents them from loading. 
+
+				<!-- Extracting messages and Spring configuration out of the API jar.
+					 It is needed due to a bug in OpenMRS, which prevents them from loading.
 					 See https://issues.openmrs.org/browse/TRUNK-3889 -->
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-dependency-plugin</artifactId>
+					<version>3.9.0</version>
 					<executions>
 						<execution>
 							<id>Expand resources</id>
@@ -304,11 +306,11 @@
 						</execution>
 					</executions>
 				</plugin>
-				
+
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-enforcer-plugin</artifactId>
-					<version>1.4.1</version>
+					<version>3.6.2</version>
 					<executions>
 						<execution>
 							<id>enforce-no-snapshots</id>
@@ -327,7 +329,58 @@
 					</executions>
 				</plugin>
 
-				<!--This plugin's configuration is used to store Eclipse m2e settings 
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-resources-plugin</artifactId>
+					<version>3.4.0</version>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<version>3.5.4</version>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-clean-plugin</artifactId>
+					<version>3.5.0</version>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-install-plugin</artifactId>
+					<version>3.1.4</version>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-deploy-plugin</artifactId>
+					<version>3.1.4</version>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-source-plugin</artifactId>
+					<version>3.4.0</version>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-javadoc-plugin</artifactId>
+					<version>3.12.0</version>
+					<configuration>
+						<tags>
+							<tag>
+								<name>should</name>
+								<placement>a</placement>
+								<head>Should:</head>
+							</tag>
+						</tags>
+					</configuration>
+				</plugin>
+
+				<!--This plugin's configuration is used to store Eclipse m2e settings
 					only. It has no influence on the Maven build itself. -->
 				<plugin>
 					<groupId>org.eclipse.m2e</groupId>
@@ -339,16 +392,17 @@
 								<pluginExecution>
 									<pluginExecutionFilter>
 										<groupId>
-											com.googlecode.maven-java-formatter-plugin
+											com.diffplug.spotless
 										</groupId>
 										<artifactId>
-											maven-java-formatter-plugin
+											spotless-maven-plugin
 										</artifactId>
 										<versionRange>
-											[0.3.1,)
+											[2.0.0,)
 										</versionRange>
 										<goals>
-											<goal>format</goal>
+											<goal>apply</goal>
+											<goal>check</goal>
 										</goals>
 									</pluginExecutionFilter>
 									<action>
@@ -382,11 +436,11 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
-		
+
 		<plugins>
 			<plugin>
-				<groupId>com.googlecode.maven-java-formatter-plugin</groupId>
-				<artifactId>maven-java-formatter-plugin</artifactId>
+				<groupId>com.diffplug.spotless</groupId>
+				<artifactId>spotless-maven-plugin</artifactId>
 			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
@@ -398,17 +452,37 @@
 	<profiles>
 		<profile>
 			<id>release</id>
+			<activation>
+				<property>
+					<name>env.CI</name>
+				</property>
+			</activation>
 			<build>
 				<plugins>
 					<plugin>
+						<groupId>com.diffplug.spotless</groupId>
+						<artifactId>spotless-maven-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>spotless-format</id>
+								<phase>none</phase>
+							</execution>
+							<execution>
+								<id>spotless-check</id>
+								<goals>
+									<goal>check</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-source-plugin</artifactId>
-						<version>2.1.2</version>
 						<executions>
 							<execution>
 								<id>attach-sources</id>
 								<goals>
-									<goal>jar</goal>
+									<goal>jar-no-fork</goal>
 								</goals>
 							</execution>
 						</executions>
@@ -416,16 +490,6 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
-						<version>2.8.1</version>
-						<configuration>
-							<tags>
-								<tag>
-									<name>should</name>
-									<placement>a</placement>
-									<head>Should:</head>
-								</tag>
-							</tags>
-						</configuration>
 						<executions>
 							<execution>
 								<id>attach-javadocs</id>


### PR DESCRIPTION
This PR creates a SNAPSHOT for version 2.0.0 of the parent POM, which mostly is just updated Maven plugin versions. This has three changes that module authors should be aware of:

1. The Google Formatter has been dropped in favour of Spotless as Google themselves have migrated to using Spotless. Both the formatting (controlled by openmrs-core) and fact that it runs by default remain unchanged.
2. I have dropped the `javaCompilerSource` and `javaCompilerTarget` properties in favour of the standard properties `maven.compiler.source` and `maven.compiler.target`.
3. `openmrsPlatformToolsVersion` now defaults to the same value as `openmrsPlatformVersion`