### PR TITLE
Add strategy to upgrade license-maven-plugin and spotless

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
       - dependency-name: "org.openmrs.web:*"
       - dependency-name: "org.openmrs.test:*"
       - dependency-name: "org.openmrs.tools:*"
+      # JDK-tiered: managed by the update-jdk-tiered-deps workflow, which respects per-JDK version caps
+      - dependency-name: "com.diffplug.spotless:spotless-maven-plugin"
+      - dependency-name: "com.mycila:license-maven-plugin"
     groups:
       maven-plugins:
         patterns:

--- a/.github/workflows/update-jdk-tiered-deps.yml
+++ b/.github/workflows/update-jdk-tiered-deps.yml
@@ -1,0 +1,57 @@
+name: Update JDK-tiered dependencies
+
+# Dependabot cannot model dependencies whose maximum version is capped by the JDK in use: it would
+# bump every declaration of a coordinate to the same latest version, breaking the JDK 8/11 builds.
+# This workflow delegates that bookkeeping to versions:update-properties, which honours the per-tier
+# version ranges configured on versions-maven-plugin in pom.xml, then opens a PR with the result.
+# Dependabot is configured to ignore these coordinates so the two do not fight over them.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays, matching the weekly Dependabot cadence
+  workflow_dispatch:
+
+# An app token (minted from the OMRS PR bot credentials) is used so the generated PR triggers the
+# build workflow; PRs opened with the default GITHUB_TOKEN do not.
+permissions:
+  contents: read
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.OMRS_PR_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.OMRS_PR_BOT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: maven
+
+      - name: Update JDK-tiered version properties
+        run: mvn -B versions:update-properties
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: chore/update-jdk-tiered-deps
+          delete-branch: true
+          commit-message: "Update JDK-tiered plugin versions"
+          title: "Update JDK-tiered plugin versions"
+          body: |
+            Automated update of the JDK-tiered plugin version properties via
+            `mvn versions:update-properties`, constrained to each tier's JDK-compatible
+            version range (configured on `versions-maven-plugin` in `pom.xml`).
+          labels: dependencies

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,18 @@
 
 		<gpg.skip>true</gpg.skip>
 
+		<!--
+			Versions for plugins whose maximum usable version is capped by the JDK in use. Each tier is
+			declared as its own property and is kept up to date by versions:update-properties, constrained
+			to a JDK-compatible range (see the versions-maven-plugin configuration). The matching profiles
+			below select the right property per JDK.
+		-->
+		<licenseVersion>4.6</licenseVersion>
+		<licenseVersionJdk11>5.0.0</licenseVersionJdk11>
+		<spotlessVersion>2.30.0</spotlessVersion>
+		<spotlessVersionJdk11>2.46.1</spotlessVersionJdk11>
+		<spotlessVersionJdk17>3.7.0</spotlessVersionJdk17>
+
 		<openmrs.license.header.inline>This Source Code Form is subject to the terms of the Mozilla Public License,
 v. 2.0. If a copy of the MPL was not distributed with this file, You can
 obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
@@ -202,6 +214,86 @@ graphic logo is a trademark of OpenMRS Inc.</openmrs.license.header.inline>
 					<version>3.15.0</version>
 				</plugin>
 
+				<!--
+					Keeps the JDK-tiered plugin version properties (declared above) current. Each property is
+					linked to its artifact and constrained to the version range usable on that tier's JDK, so
+					`mvn versions:update-properties` only ever bumps a tier within its compatible range. The
+					update-jdk-tiered-deps workflow runs this goal and opens a PR. Dependabot is configured to
+					ignore these coordinates so the two do not fight over them.
+				-->
+				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>versions-maven-plugin</artifactId>
+					<version>2.18.0</version>
+					<!-- Maintenance-only config for this POM; child modules must not inherit it -->
+					<inherited>false</inherited>
+					<configuration>
+						<generateBackupPoms>false</generateBackupPoms>
+						<!-- Only manage the explicitly listed properties; never auto-link others (e.g. openmrsPlatformVersion) -->
+						<autoLinkItems>false</autoLinkItems>
+						<properties>
+							<property>
+								<name>licenseVersion</name>
+								<!-- 5.x requires JDK 11; cap the JDK 8 tier at the 4.x line -->
+								<version>[,5.0.0)</version>
+								<dependencies>
+									<dependency>
+										<groupId>com.mycila</groupId>
+										<artifactId>license-maven-plugin</artifactId>
+										<version>${licenseVersion}</version>
+									</dependency>
+								</dependencies>
+							</property>
+							<property>
+								<name>licenseVersionJdk11</name>
+								<version>[5.0.0,)</version>
+								<dependencies>
+									<dependency>
+										<groupId>com.mycila</groupId>
+										<artifactId>license-maven-plugin</artifactId>
+										<version>${licenseVersionJdk11}</version>
+									</dependency>
+								</dependencies>
+							</property>
+							<property>
+								<name>spotlessVersion</name>
+								<!-- 2.30.0 is the last release that runs on JDK 8; 2.31.0+ require JDK 11 -->
+								<version>[,2.31.0)</version>
+								<dependencies>
+									<dependency>
+										<groupId>com.diffplug.spotless</groupId>
+										<artifactId>spotless-maven-plugin</artifactId>
+										<version>${spotlessVersion}</version>
+									</dependency>
+								</dependencies>
+							</property>
+							<property>
+								<name>spotlessVersionJdk11</name>
+								<!-- 3.x requires JDK 17; cap the JDK 11 tier at the 2.x line -->
+								<version>[2.31.0,3.0.0)</version>
+								<dependencies>
+									<dependency>
+										<groupId>com.diffplug.spotless</groupId>
+										<artifactId>spotless-maven-plugin</artifactId>
+										<version>${spotlessVersionJdk11}</version>
+									</dependency>
+								</dependencies>
+							</property>
+							<property>
+								<name>spotlessVersionJdk17</name>
+								<version>[3.0.0,)</version>
+								<dependencies>
+									<dependency>
+										<groupId>com.diffplug.spotless</groupId>
+										<artifactId>spotless-maven-plugin</artifactId>
+										<version>${spotlessVersionJdk17}</version>
+									</dependency>
+								</dependencies>
+							</property>
+						</properties>
+					</configuration>
+				</plugin>
+
 				<plugin>
 					<groupId>org.openmrs.maven.plugins</groupId>
 					<artifactId>maven-openmrs-plugin</artifactId>
@@ -246,7 +338,7 @@ graphic logo is a trademark of OpenMRS Inc.</openmrs.license.header.inline>
 				<plugin>
 					<groupId>com.mycila</groupId>
 					<artifactId>license-maven-plugin</artifactId>
-					<version>4.6</version>
+					<version>${licenseVersion}</version>
 					<configuration>
 						<licenseSets>
 							<licenseSet>
@@ -298,7 +390,7 @@ graphic logo is a trademark of OpenMRS Inc.</openmrs.license.header.inline>
 				<plugin>
 					<groupId>com.diffplug.spotless</groupId>
 					<artifactId>spotless-maven-plugin</artifactId>
-					<version>2.30.0</version>
+					<version>${spotlessVersion}</version>
 					<dependencies>
 						<dependency>
 							<groupId>org.openmrs.tools</groupId>
@@ -673,7 +765,7 @@ graphic logo is a trademark of OpenMRS Inc.</openmrs.license.header.inline>
 						<plugin>
   						<groupId>com.mycila</groupId>
   						<artifactId>license-maven-plugin</artifactId>
-  						<version>5.0.0</version>
+  						<version>${licenseVersionJdk11}</version>
 						</plugin>
 					</plugins>
 				</pluginManagement>
@@ -691,7 +783,7 @@ graphic logo is a trademark of OpenMRS Inc.</openmrs.license.header.inline>
 						<plugin>
 							<groupId>com.diffplug.spotless</groupId>
 							<artifactId>spotless-maven-plugin</artifactId>
-							<version>2.46.1</version>
+							<version>${spotlessVersionJdk11}</version>
 						</plugin>
 					</plugins>
 				</pluginManagement>
@@ -709,7 +801,7 @@ graphic logo is a trademark of OpenMRS Inc.</openmrs.license.header.inline>
 						<plugin>
 							<groupId>com.diffplug.spotless</groupId>
 							<artifactId>spotless-maven-plugin</artifactId>
-							<version>3.6.0</version>
+							<version>${spotlessVersionJdk17}</version>
 						</plugin>
 					</plugins>
 				</pluginManagement>


### PR DESCRIPTION
In some cases, the versions of plugins we use varies depending on the JDK being used. For example, Spotless won't run properly past 2.30.0 on JDK8. Spotless mistakenly (in my view) did not regard this as a "breaking" change, so 2.31.0 only runs on JDK11+ (though it can _format_ Java 8 code). Similarly, spotless 3.x only runs on JDK17+. Dependabot doesn't seem capable of handling these kind of conditional rules, so for plugins like spotless and the license plugin, we use an alternative maintenance strategy built around the Maven versions plugin, which supports the somewhat complex policy we need of having several different verisons appropriately managed.

Note that this doesn't make things entirely maintenance-free, as eventually, it seems likely that Java 21 or 25 will be the minimum version supported for some future version of both of these tools. However, this does establish a pattern we can use for these results.